### PR TITLE
[CBP-42405] chore: Update latest image version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - id: invoke-ansible-actions
       name: invoke-ansible-actions
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/ansible-actions:main-54c870441a3448f8bdb9881b8b69e75902f99d95
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/ansible-actions:main-cc7c03554a3bc1182b0af7bdbf1159de48a1d932
       shell: sh
       run: |
         set -x


### PR DESCRIPTION
Update docker image tag to latest version from `action_artifacts.json`.